### PR TITLE
Fix catalog service startup race condition

### DIFF
--- a/.gitpod/automations.yaml
+++ b/.gitpod/automations.yaml
@@ -47,7 +47,27 @@ services:
     commands:
       start: |
         cd /workspaces/gitpodflix-demo/backend/catalog
-        PORT=3001 npx nodemon src/index.ts
+        
+        # Ensure dependencies are installed
+        echo "Ensuring dependencies are installed..."
+        npm install
+        
+        # Wait for ts-node to be available
+        echo "Waiting for ts-node to be available..."
+        for i in {1..30}; do
+          if [ -f "node_modules/.bin/ts-node" ]; then
+            echo "✓ ts-node is available"
+            break
+          fi
+          if [ $i -eq 30 ]; then
+            echo "✗ Timeout waiting for ts-node"
+            exit 1
+          fi
+          echo "Waiting for ts-node... attempt $i/30"
+          sleep 1
+        done
+        
+        PORT=3001 npm run dev
       ready: |
         if curl -s http://localhost:3001/health > /dev/null; then
           echo "Catalog service is ready"

--- a/backend/catalog/package.json
+++ b/backend/catalog/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.ts",
   "scripts": {
     "start": "ts-node src/index.ts",
-    "dev": "nodemon src/index.ts",
+    "dev": "nodemon --exec ts-node src/index.ts",
     "build": "tsc",
     "test": "jest",
     "setup": "./scripts/setup.sh"
@@ -26,6 +26,11 @@
     "nodemon": "^3.0.2",
     "jest": "^29.7.0",
     "@types/jest": "^29.5.11",
-    "ts-jest": "^29.1.1"
+        "ts-jest": "^29.1.1"
+  },
+  "nodemonConfig": {
+    "watch": ["src"],
+    "ext": "ts,json",
+    "exec": "ts-node src/index.ts"
   }
-} 
+}


### PR DESCRIPTION
- Use npm run dev instead of npx nodemon to ensure local dependencies
- Add dependency installation check in automations
- Configure nodemon to properly use ts-node
- Add nodemon configuration in package.json