### PR TITLE
Update automations.yaml

### DIFF
--- a/.gitpod/automations.yaml
+++ b/.gitpod/automations.yaml
@@ -62,8 +62,6 @@ services:
     triggeredBy:
       - postDevcontainerStart
       - postEnvironmentStart
-    dependsOn:
-      - postgres
     commands:
       start: |
         cd /workspaces/gitpodflix-demo/backend/catalog
@@ -131,8 +129,6 @@ services:
     triggeredBy:
       - postDevcontainerStart
       - postEnvironmentStart
-    dependsOn:
-      - catalog
     commands:
       start: |
         cd /workspaces/gitpodflix-demo/frontend
@@ -190,8 +186,6 @@ tasks:
     triggeredBy:
       - manual
       - postEnvironmentStart
-    dependsOn:
-      - postgres
     command: |
       cd /workspaces/gitpodflix-demo/database/main
 
@@ -242,8 +236,6 @@ tasks:
     triggeredBy:
       - postEnvironmentStart
       - manual
-    dependsOn:
-      - gitpod-flix
     command: |
       # Wait for services to be ready before opening ports
       echo "Waiting for services to be ready before opening ports..."


### PR DESCRIPTION
removed all dependsOn fields from the automations.yaml file:

Removed dependsOn: [postgres] from the catalog service
Removed dependsOn: [catalog] from the gitpod-flix service
Removed dependsOn: [postgres] from the seedDatabase task
Removed dependsOn: [gitpod-flix] from the openDemoPorts task