### PR TITLE
Add Backstage catalog files for all components

### DIFF
--- a/backend/catalog/backstage.yml
+++ b/backend/catalog/backstage.yml
@@ -1,0 +1,50 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: catalog-service
+  description: Catalog service for Gitpod Flix
+  tags:
+    - nodejs
+    - express
+    - typescript
+    - api
+  annotations:
+    github.com/project-slug: gitpod-samples/gitpodflix-demo
+spec:
+  type: service
+  lifecycle: production
+  owner: team-platform
+  system: gitpodflix
+  providesApis:
+    - catalog-api
+  dependsOn:
+    - component:database-service
+---
+apiVersion: backstage.io/v1alpha1
+kind: API
+metadata:
+  name: catalog-api
+  description: REST API for movie catalog operations
+spec:
+  type: openapi
+  lifecycle: production
+  owner: team-platform
+  system: gitpodflix
+  definition: |
+    openapi: 3.0.0
+    info:
+      title: Catalog API
+      version: 1.0.0
+    paths:
+      /api/movies:
+        get:
+          summary: Get all movies
+      /api/search:
+        get:
+          summary: Search movies with filters
+      /api/suggestions:
+        get:
+          summary: Get search suggestions
+      /health:
+        get:
+          summary: Service health check

--- a/backstage.yml
+++ b/backstage.yml
@@ -1,0 +1,22 @@
+apiVersion: backstage.io/v1alpha1
+kind: System
+metadata:
+  name: gitpodflix
+  description: Modern streaming platform demo showcasing full-stack development in Gitpod
+  tags:
+    - streaming
+    - demo
+    - full-stack
+  annotations:
+    github.com/project-slug: gitpod-samples/gitpodflix-demo
+spec:
+  owner: team-platform
+  domain: media
+---
+apiVersion: backstage.io/v1alpha1
+kind: Domain
+metadata:
+  name: media
+  description: Media and streaming services domain
+spec:
+  owner: team-platform

--- a/database/backstage.yml
+++ b/database/backstage.yml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: database-service
+  description: PostgreSQL database with full-text search for movie catalog
+  tags:
+    - postgresql
+    - database
+    - docker
+  annotations:
+    github.com/project-slug: gitpod-samples/gitpodflix-demo
+spec:
+  type: database
+  lifecycle: production
+  owner: team-platform
+  system: gitpodflix

--- a/frontend/backstage.yml
+++ b/frontend/backstage.yml
@@ -1,0 +1,22 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: frontend
+  description: React frontend application for Gitpod Flix streaming platform
+  tags:
+    - react
+    - typescript
+    - vite
+    - tailwindcss
+    - frontend
+  annotations:
+    github.com/project-slug: gitpod-samples/gitpodflix-demo
+spec:
+  type: website
+  lifecycle: production
+  owner: team-platform
+  system: gitpodflix
+  consumesApis:
+    - catalog-api
+  dependsOn:
+    - component:catalog-service


### PR DESCRIPTION
## Changes

Adds Backstage catalog integration files to enable component discovery and visualization in Backstage.

### Files Added

- **Root `backstage.yml`**: System and domain definitions for GitpodFlix
- **`backend/catalog/backstage.yml`**: Catalog service component and API definition
- **`frontend/backstage.yml`**: Frontend website component
- **`database/backstage.yml`**: PostgreSQL database component

### Component Relationships

- Frontend consumes the catalog API and depends on catalog service
- Catalog service provides the catalog API and depends on database service
- All components are part of the gitpodflix system in the media domain

### Benefits

- Enables Backstage catalog integration
- Documents component architecture and dependencies
- Provides API definitions for service discovery
- Establishes ownership and lifecycle metadata